### PR TITLE
Fix main to support whitespaces at filename

### DIFF
--- a/cdm/src/main/java/ucar/nc2/NCdumpW.java
+++ b/cdm/src/main/java/ucar/nc2/NCdumpW.java
@@ -693,17 +693,25 @@ public class NCdumpW {
       System.out.println(usage);
       return;
     }
-
-    StringBuilder sbuff = new StringBuilder();
-    for (String arg : args) {
-      sbuff.append(arg);
-      sbuff.append(" ");
-    }
-
     try {
       Writer writer = new BufferedWriter(new OutputStreamWriter(System.out, CDM.utf8Charset));
-      NCdumpW.print(sbuff.toString(), writer, null);
-
+      // pull out the filename from the command
+      String filename = args[0];
+      ucar.nc2.util.CancelTask ct=null;
+      try (NetcdfFile nc = NetcdfDataset.openFile(filename, ct)) {
+        // the rest of the command
+        StringBuilder command = new StringBuilder();
+        for (int i=1; i < args.length; i++) {
+          command.append(args[i]);
+          command.append(" ");
+        }
+        print(nc, command.toString(), writer, ct);
+    } catch (java.io.FileNotFoundException e) {ls -la 
+        writer.write("file not found= ");
+        writer.write(filename);
+      } finally {
+        writer.close();
+      }
     } catch (IOException ioe) {
       ioe.printStackTrace();
     }


### PR DESCRIPTION
The `NCdumpW.main` doesn't support filenames with escaped or quoted whitespaces. 
```shell
$ java ucar.nc2.NCdumpW "File Name With Whitespaces.nc" 
file not found= File
```
This PR fix this issue. 

Probably this fix needs to be extended to the rest of arguments.